### PR TITLE
feat: implement `SetNotNullableIfMinLengthGreaterThenZero` for `FluentValidation.GreaterThan`

### DIFF
--- a/src/Swashbuckle.FluentValidation/DefaultFluentValidationRuleProvider.cs
+++ b/src/Swashbuckle.FluentValidation/DefaultFluentValidationRuleProvider.cs
@@ -44,10 +44,10 @@ public class DefaultFluentValidationRuleProvider : IFluentValidationRuleProvider
             .WithApply(context =>
             {
                 if (context.Property.Type == "string")
-                    context.Property.SetNewMin(p => p.MinLength, 1, _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
+                    context.Property.SetNewMin(p => p.MinLength, 1, _options.Value.SetNotNullableIfMinLengthGreaterThenZero, _options.Value.SetNotNullableIfMinimumGreaterThenZero);
 
                 if (context.Property.Type == "array")
-                    context.Property.SetNewMin(p => p.MinItems, 1, _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
+                    context.Property.SetNewMin(p => p.MinItems, 1, _options.Value.SetNotNullableIfMinLengthGreaterThenZero, _options.Value.SetNotNullableIfMinimumGreaterThenZero);
             });
 
         yield return new FluentValidationRule("Length")
@@ -63,7 +63,7 @@ public class DefaultFluentValidationRuleProvider : IFluentValidationRuleProvider
                         schemaProperty.SetNewMax(p => p.MaxItems, lengthValidator.Max);
 
                     if (lengthValidator.Min > 0)
-                        schemaProperty.SetNewMin(p => p.MinItems, lengthValidator.Min, _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
+                        schemaProperty.SetNewMin(p => p.MinItems, lengthValidator.Min, _options.Value.SetNotNullableIfMinLengthGreaterThenZero, _options.Value.SetNotNullableIfMinimumGreaterThenZero);
                 }
                 else
                 {
@@ -71,7 +71,7 @@ public class DefaultFluentValidationRuleProvider : IFluentValidationRuleProvider
                         schemaProperty.SetNewMax(p => p.MaxLength, lengthValidator.Max);
 
                     if (lengthValidator.Min > 0)
-                        schemaProperty.SetNewMin(p => p.MinLength, lengthValidator.Min, _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
+                        schemaProperty.SetNewMin(p => p.MinLength, lengthValidator.Min, _options.Value.SetNotNullableIfMinLengthGreaterThenZero, _options.Value.SetNotNullableIfMinimumGreaterThenZero);
                 }
             });
 
@@ -133,12 +133,12 @@ public class DefaultFluentValidationRuleProvider : IFluentValidationRuleProvider
 
                     if (comparisonValidator.Comparison == Comparison.GreaterThanOrEqual)
                     {
-                        schemaProperty.SetNewMin(p => p.Minimum, valueToCompare, _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
+                        schemaProperty.SetNewMin(p => p.Minimum, valueToCompare, _options.Value.SetNotNullableIfMinLengthGreaterThenZero, _options.Value.SetNotNullableIfMinimumGreaterThenZero);
                     }
                     else if (comparisonValidator.Comparison == Comparison.GreaterThan)
                     {
                         schemaProperty.ExclusiveMinimum = true;
-                        schemaProperty.SetNewMin(p => p.Minimum, valueToCompare, _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
+                        schemaProperty.SetNewMin(p => p.Minimum, valueToCompare, _options.Value.SetNotNullableIfMinLengthGreaterThenZero, _options.Value.SetNotNullableIfMinimumGreaterThenZero);
                     }
                     else if (comparisonValidator.Comparison == Comparison.LessThanOrEqual)
                     {
@@ -163,7 +163,7 @@ public class DefaultFluentValidationRuleProvider : IFluentValidationRuleProvider
 
                 if (betweenValidator.From.IsNumeric())
                 {
-                    schemaProperty.SetNewMin(p => p.Minimum, betweenValidator.From.NumericToDecimal(), _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
+                    schemaProperty.SetNewMin(p => p.Minimum, betweenValidator.From.NumericToDecimal(), _options.Value.SetNotNullableIfMinLengthGreaterThenZero, _options.Value.SetNotNullableIfMinimumGreaterThenZero);
 
                     if (betweenValidator.Name == "ExclusiveBetweenValidator")
                     {

--- a/src/Swashbuckle.FluentValidation/DefaultFluentValidationRuleProvider.cs
+++ b/src/Swashbuckle.FluentValidation/DefaultFluentValidationRuleProvider.cs
@@ -137,8 +137,8 @@ public class DefaultFluentValidationRuleProvider : IFluentValidationRuleProvider
                     }
                     else if (comparisonValidator.Comparison == Comparison.GreaterThan)
                     {
-                        schemaProperty.SetNewMin(p => p.Minimum, valueToCompare, _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
                         schemaProperty.ExclusiveMinimum = true;
+                        schemaProperty.SetNewMin(p => p.Minimum, valueToCompare, _options.Value.SetNotNullableIfMinLengthGreaterThenZero);
                     }
                     else if (comparisonValidator.Comparison == Comparison.LessThanOrEqual)
                     {
@@ -146,8 +146,8 @@ public class DefaultFluentValidationRuleProvider : IFluentValidationRuleProvider
                     }
                     else if (comparisonValidator.Comparison == Comparison.LessThan)
                     {
-                        schemaProperty.SetNewMax(p => p.Maximum, valueToCompare);
                         schemaProperty.ExclusiveMaximum = true;
+                        schemaProperty.SetNewMax(p => p.Maximum, valueToCompare);
                     }
                 }
             });

--- a/src/Swashbuckle.FluentValidation/OpenApi.FluentValidation/FluentValidation/ISchemaGenerationOptions.cs
+++ b/src/Swashbuckle.FluentValidation/OpenApi.FluentValidation/FluentValidation/ISchemaGenerationOptions.cs
@@ -13,9 +13,14 @@ namespace OpenApi.FluentValidation;
 public interface ISchemaGenerationOptions
 {
     /// <summary>
-    /// Gets a value indicating whether property should be set to not nullable if MinLength is greater then zero.
+    /// Gets a value indicating whether property should be set to not nullable if MinLength is greater than zero.
     /// </summary>
     bool SetNotNullableIfMinLengthGreaterThenZero { get; }
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether property should be set to not nullable if Minimum is greater than zero.
+    /// </summary>
+    bool SetNotNullableIfMinimumGreaterThenZero { get; }
 
     /// <summary>
     /// Gets a value indicating whether schema generator should use AllOf for multiple rules (for example for multiple patterns).
@@ -60,10 +65,16 @@ public interface ISchemaGenerationOptions
 public class SchemaGenerationOptions : ISchemaGenerationOptions
 {
     /// <summary>
-    /// Gets or sets a value indicating whether property should be set to not nullable if MinLength is greater then zero.
+    /// Gets or sets a value indicating whether property should be set to not nullable if MinLength is greater than zero.
     /// Default: false.
     /// </summary>
     public bool SetNotNullableIfMinLengthGreaterThenZero { get; set; } = false;
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether property should be set to not nullable if Minimum is greater than zero.
+    /// Default: false.
+    /// </summary>
+    public bool SetNotNullableIfMinimumGreaterThenZero { get; set; } = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether schema generator should use AllOf for multiple rules (for example for multiple patterns).

--- a/src/Swashbuckle.FluentValidation/OpenApi.FluentValidation/FluentValidation/SchemaGenerationOptionsExtensions.cs
+++ b/src/Swashbuckle.FluentValidation/OpenApi.FluentValidation/FluentValidation/SchemaGenerationOptionsExtensions.cs
@@ -39,6 +39,7 @@ public static class SchemaGenerationOptionsExtensions
     public static SchemaGenerationOptions SetFrom(this SchemaGenerationOptions options, ISchemaGenerationOptions other)
     {
         options.SetNotNullableIfMinLengthGreaterThenZero = other.SetNotNullableIfMinLengthGreaterThenZero;
+        options.SetNotNullableIfMinimumGreaterThenZero = other.SetNotNullableIfMinimumGreaterThenZero;
         options.UseAllOfForMultipleRules = other.UseAllOfForMultipleRules;
         options.ValidatorSearch = other.ValidatorSearch;
         options.NameResolver = other.NameResolver;

--- a/src/Swashbuckle.FluentValidation/OpenApi/OpenApiExtensions.cs
+++ b/src/Swashbuckle.FluentValidation/OpenApi/OpenApiExtensions.cs
@@ -21,6 +21,13 @@ public static class OpenApiExtensions
         {
             schemaProperty.Nullable = false;
         }
+        if (
+            schemaProperty.Minimum.HasValue && (
+            schemaProperty.ExclusiveMinimum.GetValueOrDefault(false) ? schemaProperty.Minimum >= 0 : schemaProperty.Minimum > 0)
+        )
+        {
+            schemaProperty.Nullable = false;
+        }
     }
 
     internal static void SetNewMax(this OpenApiSchema schemaProperty, Expression<Func<OpenApiSchema, int?>> prop, int? newValue)

--- a/src/Swashbuckle.FluentValidation/OpenApi/OpenApiExtensions.cs
+++ b/src/Swashbuckle.FluentValidation/OpenApi/OpenApiExtensions.cs
@@ -21,6 +21,13 @@ public static class OpenApiExtensions
         {
             schemaProperty.Nullable = false;
         }
+    }
+    
+    /// <summary>
+    /// Sets Nullable to false if Minimum > 0 or Minimum >= 0 when ExclusiveMinimum is true.
+    /// </summary>
+    internal static void SetNotNullableIfMinimumGreaterThenZero(this OpenApiSchema schemaProperty)
+    {
         if (
             schemaProperty.Minimum.HasValue && (
             schemaProperty.ExclusiveMinimum.GetValueOrDefault(false) ? schemaProperty.Minimum >= 0 : schemaProperty.Minimum > 0)
@@ -50,7 +57,7 @@ public static class OpenApiExtensions
         }
     }
 
-    internal static void SetNewMin(this OpenApiSchema schemaProperty, Expression<Func<OpenApiSchema, int?>> prop, int? newValue, bool setNotNullableIfMinLengthGreaterThenZero = true)
+    internal static void SetNewMin(this OpenApiSchema schemaProperty, Expression<Func<OpenApiSchema, int?>> prop, int? newValue, bool setNotNullableIfMinLengthGreaterThenZero = true, bool setNotNullableIfMinimumGreaterThenZero = true)
     {
         if (newValue.HasValue)
         {
@@ -62,9 +69,11 @@ public static class OpenApiExtensions
         // SetNotNullableIfMinLengthGreaterThenZero should be optionated because FV allows nulls for MinLength validator
         if (setNotNullableIfMinLengthGreaterThenZero)
             schemaProperty.SetNotNullableIfMinLengthGreaterThenZero();
+        if (setNotNullableIfMinimumGreaterThenZero)
+            schemaProperty.SetNotNullableIfMinimumGreaterThenZero();
     }
 
-    internal static void SetNewMin(this OpenApiSchema schemaProperty, Expression<Func<OpenApiSchema, decimal?>> prop, decimal? newValue, bool setNotNullableIfMinLengthGreaterThenZero = true)
+    internal static void SetNewMin(this OpenApiSchema schemaProperty, Expression<Func<OpenApiSchema, decimal?>> prop, decimal? newValue, bool setNotNullableIfMinLengthGreaterThenZero = true, bool setNotNullableIfMinimumGreaterThenZero = true)
     {
         if (newValue.HasValue)
         {
@@ -76,6 +85,8 @@ public static class OpenApiExtensions
         // SetNotNullableIfMinLengthGreaterThenZero should be optionated because FV allows nulls for MinLength validator
         if (setNotNullableIfMinLengthGreaterThenZero)
             schemaProperty.SetNotNullableIfMinLengthGreaterThenZero();
+        if (setNotNullableIfMinimumGreaterThenZero)
+            schemaProperty.SetNotNullableIfMinimumGreaterThenZero();
     }
 
     private static int NewMaxValue(int? current, int newValue) => current.HasValue ? Math.Min(current.Value, newValue) : newValue;

--- a/tests/Swashbuckle.FluentValidation.Tests/SchemaGenerationTests.cs
+++ b/tests/Swashbuckle.FluentValidation.Tests/SchemaGenerationTests.cs
@@ -444,9 +444,9 @@ public partial class SchemaGenerationTests : UnitTestBase
     }
     
     [Fact]
-    public void GreaterThan_ShouldRespect_Set_NotNullable_GreaterThenZero()
+    public void GreaterThan_ShouldRespect_Set_NotNullable_MinimumGreaterThenZero()
     {
-        // without options. property is nullable, min length is set.
+        // without options. property is nullable, minimum is set.
         new SchemaBuilder<TestNumberEntity>()
             .AddRule(entity => entity.IntValue, rule => rule.GreaterThan(0), schema => {
                 Assert.False(schema.Nullable);
@@ -471,38 +471,38 @@ public partial class SchemaGenerationTests : UnitTestBase
         
         // SetNotNullableIfMinLengthGreaterThenZero = false
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = false)
             .AddRule(entity => entity.IntValue, rule => rule.GreaterThan(0), schema => {
                 Assert.False(schema.Nullable);
                 Assert.Equal(0, schema.Minimum);
             });
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = false)
             .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
                 Assert.False(schema.Nullable);
                 Assert.Equal(1, schema.Minimum);
             });
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = false)
             .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(0), schema => {
                 Assert.False(schema.Nullable);
                 Assert.Equal(0, schema.Minimum);
             });
         // Nullable
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = false)
             .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThan(0), schema => {
                 Assert.True(schema.Nullable);
                 Assert.Equal(0, schema.Minimum);
             });
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = false)
             .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
                 Assert.True(schema.Nullable);
                 Assert.Equal(1, schema.Minimum);
             });
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = false)
             .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(0), schema => {
                 Assert.True(schema.Nullable);
                 Assert.Equal(0, schema.Minimum);
@@ -510,38 +510,38 @@ public partial class SchemaGenerationTests : UnitTestBase
 
         // SetNotNullableIfMinLengthGreaterThenZero = true
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = true)
             .AddRule(entity => entity.IntValue, rule => rule.GreaterThan(0), schema => {
                 Assert.False(schema.Nullable);
                 Assert.Equal(0, schema.Minimum);
             });
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = true)
             .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
                 Assert.False(schema.Nullable);
                 Assert.Equal(1, schema.Minimum);
             });
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = true)
             .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(0), schema => {
                 Assert.False(schema.Nullable);
                 Assert.Equal(0, schema.Minimum);
             });
         //Nullable
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = true)
             .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThan(0), schema => {
                 Assert.False(schema.Nullable);
                 Assert.Equal(0, schema.Minimum);
             });
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = true)
             .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
                 Assert.False(schema.Nullable);
                 Assert.Equal(1, schema.Minimum);
             });
         new SchemaBuilder<TestNumberEntity>()
-            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinimumGreaterThenZero = true)
             .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(0), schema => {
                 Assert.True(schema.Nullable);
                 Assert.Equal(0, schema.Minimum);

--- a/tests/Swashbuckle.FluentValidation.Tests/SchemaGenerationTests.cs
+++ b/tests/Swashbuckle.FluentValidation.Tests/SchemaGenerationTests.cs
@@ -388,6 +388,11 @@ public partial class SchemaGenerationTests : UnitTestBase
 
         public string? NullableTextValue { get; set; }
     }
+    public class TestNumberEntity
+    {
+        public int IntValue { get; set; }
+        public int? NullableIntValue { get; set; }
+    }
 
     [Fact]
     public void TextNullability()
@@ -436,6 +441,112 @@ public partial class SchemaGenerationTests : UnitTestBase
                 Assert.False(schema.Nullable);
                 Assert.Equal(1, schema.MinLength);
             });
+    }
+    
+    [Fact]
+    public void GreaterThan_ShouldRespect_Set_NotNullable_GreaterThenZero()
+    {
+        // without options. property is nullable, min length is set.
+        new SchemaBuilder<TestNumberEntity>()
+            .AddRule(entity => entity.IntValue, rule => rule.GreaterThan(0), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(1, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThan(0), schema => {
+                Assert.True(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+        
+        new SchemaBuilder<TestNumberEntity>()
+            .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
+                Assert.True(schema.Nullable);
+                Assert.Equal(1, schema.Minimum);
+            });
+        
+        // SetNotNullableIfMinLengthGreaterThenZero = false
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .AddRule(entity => entity.IntValue, rule => rule.GreaterThan(0), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(1, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(0), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+        // Nullable
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThan(0), schema => {
+                Assert.True(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
+                Assert.True(schema.Nullable);
+                Assert.Equal(1, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = false)
+            .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(0), schema => {
+                Assert.True(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+
+        // SetNotNullableIfMinLengthGreaterThenZero = true
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .AddRule(entity => entity.IntValue, rule => rule.GreaterThan(0), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(1, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .AddRule(entity => entity.IntValue, rule => rule.GreaterThanOrEqualTo(0), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+        //Nullable
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThan(0), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(1), schema => {
+                Assert.False(schema.Nullable);
+                Assert.Equal(1, schema.Minimum);
+            });
+        new SchemaBuilder<TestNumberEntity>()
+            .ConfigureSchemaGenerationOptions(options => options.SetNotNullableIfMinLengthGreaterThenZero = true)
+            .AddRule(entity => entity.NullableIntValue, rule => rule.GreaterThanOrEqualTo(0), schema => {
+                Assert.True(schema.Nullable);
+                Assert.Equal(0, schema.Minimum);
+            });
+
     }
 
     public class BestShot


### PR DESCRIPTION
Fixes `Swashbuckle` to mark as required numeric fields based on `GreaterThan` FluentValidation and `SetNotNullableIfMinLengthGreaterThenZero` active.

I originally posted the issue on forked repo:
- https://github.com/micro-elements/MicroElements.Swashbuckle.FluentValidation/issues/154

Note: My first here, so please let me know if need to follow some contributing rules